### PR TITLE
Fix typo in debounce code (missing parens) so timing works as expected

### DIFF
--- a/StenoFW.ino
+++ b/StenoFW.ino
@@ -125,7 +125,7 @@ void checkAlreadyDebouncingKeys() {
         debouncingKeys[i][j] = false;
         continue;
       }
-      if (debouncingKeys[i][j] == true && micros() - debouncingMicros[i][j] / 1000 > debounceMillis) {
+      if (debouncingKeys[i][j] == true && (micros() - debouncingMicros[i][j]) / 1000 > debounceMillis) {
         isStrokeInProgress = true;
         currentChord[i][j] = true;
         return;


### PR DESCRIPTION
This is a proposed fix for Issue #2 that I previously reported.
